### PR TITLE
Dockerfile: Base off of Wolfi and use tini to run BSS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 FROM alpine:3.15
+FROM cgr.dev/chainguard/wolfi-base
 LABEL maintainer="Hewlett Packard Enterprise"
 EXPOSE 27778
 STOPSIGNAL SIGTERM
+
+RUN apk add --no-cache tini
 
 # Setup environment variables.
 ENV HSM_URL=http://smd:27779
@@ -56,5 +59,7 @@ COPY .version /
 # nobody 65534:65534
 USER 65534:65534
 
-# Set up the command to start the service, the run the init script.
-CMD boot-script-service $BSS_OPTS --cloud-init-address localhost --postgres --postgres-host $POSTGRES_HOST --postgres-port $POSTGRES_PORT --retry-delay=$BSS_RETRY_DELAY --hsm $HSM_URL --hsm-retrieval-delay=$BSS_HSM_RETRIEVAL_DELAY
+# Set up the command to start the service.
+CMD /usr/local/bin/boot-script-service $BSS_OPTS --cloud-init-address localhost --postgres --postgres-host $POSTGRES_HOST --postgres-port $POSTGRES_PORT --retry-delay=$BSS_RETRY_DELAY --hsm $HSM_URL --hsm-retrieval-delay=$BSS_HSM_RETRIEVAL_DELAY
+
+ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
### Summary and Scope

Use `tini` from Wolfi Linux to run BSS to avoid run errors.

### Issues and Related PRs

* Fixes BSS run issue in https://github.com/bikeshack/ochami-lanl-dev/pull/19

### Testing

Tested on:

* Cable Guys SI Cluster (cg-head and compute nodes)
  - This is a system of x86-64 Gigabyte 272-Z32-00 machines running Rocky Linux 8.8

### Risks and Mitigations

None known.
